### PR TITLE
Fix stutter on the voice example

### DIFF
--- a/example/src/examples/voice.tscn
+++ b/example/src/examples/voice.tscn
@@ -44,9 +44,7 @@ text = "Voice Example"
 layout_mode = 2
 text = "Here we test some functionality for Steam Voice to capture and playback voice chat.
 
-You can press-to-talk or toggle voice on/off.  To hear yourself, enable loopback.  You can also change the optimal sample rate by pressing the corresponding button.  However, as Valve notes, using the optimal sample rate will result in lower CPU usage but may sound worse.
-
-You may also notice the playback seems a little jumpy or choppy.  No one has quite figured out why that is yet.  If you can solve this, please open a pull-request!"
+You can press-to-talk or toggle voice on/off.  To hear yourself, enable loopback.  You can also change the optimal sample rate by pressing the corresponding button.  However, as Valve notes, using the optimal sample rate will result in lower CPU usage but may sound worse."
 fit_content = true
 metadata/_edit_lock_ = true
 


### PR DESCRIPTION
This should fix the audio stuttering issue on the voice example. Instead of setting the audio stream every time it receives voice data it now uses the `push_frame()` method on the `AudioStreamGeneratorPlayback`. The playback takes floats from -1 to 1 that represent each sample's amplitude. [This forum post](https://forum.godotengine.org/t/how-to-read-audio-samples-as-1-1-floats/19957) was really helpful for converting the 16-bit PCM data to usable floats.

https://github.com/GodotSteam/GodotSteam-Example-Project/assets/67610180/64f6a185-c2e7-4f40-b8c1-40163cfea340

https://github.com/GodotSteam/GodotSteam-Example-Project/assets/67610180/c1035d43-c588-4ccd-916c-9b7f2f272b1c